### PR TITLE
fix hang when search includes a word less than 3 characters long

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,11 +36,12 @@ module.exports = function (version, length, map) {
         while(aborts.length) aborts.shift()()
       })
 
-      var terms = opts.query.trim().split(/[^\w]+/).filter(Boolean)
-      var mask = 0, found = {}, ended = 0
-      var aborts = terms.filter(function (e) {
+      var terms = opts.query.trim().split(/[^\w]+/).filter(Boolean).filter(function (e) {
         return e.length >= 3
-      }).map(function (term, i) {
+      })
+      
+      var mask = 0, found = {}, ended = 0
+      var aborts = terms.map(function (term, i) {
         mask |= 1 << i
         var sink
         pull(


### PR DESCRIPTION
If you search contains a word that is less than 3 characters long, the search hangs and never completes. This is because the code is filtering out words less than 3 characters long, but then still expecting to get results for all words.

This PR fixes this by moving the filter so that it covers the result counting as well as the searching.

cc @dominictarr 